### PR TITLE
FIX : Text 공용 컴포넌트의 styled component 명칭 변경

### DIFF
--- a/src/components/Text/Text.js
+++ b/src/components/Text/Text.js
@@ -3,9 +3,9 @@ import * as S from './Text.styled';
 
 const Text = ({ children, fontSize, fontWeight }) => {
   return (
-    <S.Text fontSize={fontSize} fontWeight={fontWeight}>
+    <S.StText fontSize={fontSize} fontWeight={fontWeight}>
       {children}
-    </S.Text>
+    </S.StText>
   );
 };
 

--- a/src/components/Text/Text.styled.js
+++ b/src/components/Text/Text.styled.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-export const Text = styled.p`
+export const StText = styled.p`
   ${({ fontSize, fontWeight }) =>
     `font-size: ${fontSize ? fontSize : 15}px; 
     font-weight: ${fontWeight === 'bold' ? 700 : 400}`}


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [x] 컨벤션 수정

<br />

## :: 구현 목표 
- 공용으로 작성한 Text 컴포넌트의 명칭이 styled component의 이름과 동일하여 다른곳에서 사용 시 import가 정상적으로 작동되지 않음
- 구분이 가능하도록 명칭을 변경

<br />

## :: 구현 사항 설명
- styled component의 명칭을 `St`를 붙여 이름 변경함

<br />

## :: 성장 포인트 
- 네이밍 컨벤션이 이리도 중요하다는점을 다시한번 깨닫게 되었습니다 🥲

