### PR TITLE
ADD : itemCard 레이아웃 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^13.5.0",
         "axios": "^0.27.2",
-        "dotenv": "^16.0.1",
+        "rc-progress": "^3.4.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.3.0",
@@ -5526,6 +5526,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
     },
+    "node_modules/classnames": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+    },
     "node_modules/clean-css": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.0.tgz",
@@ -6600,14 +6605,6 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
-      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ==",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/dotenv-expand": {
@@ -13945,6 +13942,39 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rc-progress": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/rc-progress/-/rc-progress-3.4.0.tgz",
+      "integrity": "sha512-ZuMyOzzTkZnn+EKqGQ7YHzrvGzBtcCCVjx1McC/E/pMTvr6GWVfVRSawDlWsscxsJs7MkqSTwCO6Lu4IeoY2zQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "^2.2.6",
+        "rc-util": "^5.16.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-util": {
+      "version": "5.22.5",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.22.5.tgz",
+      "integrity": "sha512-awD2TGMGU97OZftT2R3JwrHWjR8k/xIwqjwcivPskciweUdgXE7QsyXkBKVSBHXS+c17AWWMDWuKWsJSheQy8g==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "react-is": "^16.12.0",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-util/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
     "node_modules/react": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
@@ -20974,6 +21004,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
     },
+    "classnames": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
+    },
     "clean-css": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.0.tgz",
@@ -21754,11 +21789,6 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
-    },
-    "dotenv": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.1.tgz",
-      "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ=="
     },
     "dotenv-expand": {
       "version": "5.1.0",
@@ -26881,6 +26911,33 @@
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
+        }
+      }
+    },
+    "rc-progress": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/rc-progress/-/rc-progress-3.4.0.tgz",
+      "integrity": "sha512-ZuMyOzzTkZnn+EKqGQ7YHzrvGzBtcCCVjx1McC/E/pMTvr6GWVfVRSawDlWsscxsJs7MkqSTwCO6Lu4IeoY2zQ==",
+      "requires": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "^2.2.6",
+        "rc-util": "^5.16.1"
+      }
+    },
+    "rc-util": {
+      "version": "5.22.5",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.22.5.tgz",
+      "integrity": "sha512-awD2TGMGU97OZftT2R3JwrHWjR8k/xIwqjwcivPskciweUdgXE7QsyXkBKVSBHXS+c17AWWMDWuKWsJSheQy8g==",
+      "requires": {
+        "@babel/runtime": "^7.18.3",
+        "react-is": "^16.12.0",
+        "shallowequal": "^1.1.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^0.27.2",
-    "dotenv": "^16.0.1",
+    "rc-progress": "^3.4.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.3.0",

--- a/src/hooks/useFetch.js
+++ b/src/hooks/useFetch.js
@@ -1,0 +1,26 @@
+import { useCallback, useState, useEffect } from 'react';
+
+export default function useFetch({ httpClient, url, skip = false }) {
+  const [payload, setPayload] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const getData = useCallback(async () => {
+    try {
+      const { data } = await httpClient.getData(url);
+      setPayload(data);
+    } catch (e) {
+      console.error('error!!', e);
+      setError('error!!');
+    } finally {
+      setLoading(false);
+    }
+  }, [httpClient, url]);
+
+  useEffect(() => {
+    if (skip) return;
+    getData();
+  }, [getData, skip]);
+
+  return { payload, loading, error, getData };
+}

--- a/src/pages/Main/ItemCard/ItemCard.js
+++ b/src/pages/Main/ItemCard/ItemCard.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import * as S from './ItemCard.styled';
+import Text from '../../../components/Text/Text';
+import { Line } from 'rc-progress';
+
+const ItemCard = ({ fundItem }) => {
+  return (
+    <S.WrapperCard>
+      <S.ImageBox>
+        <S.CardImage src={fundItem.image_url} />
+      </S.ImageBox>
+      <S.WrapperInfo>
+        <S.WrapperTitle>
+          <Text fontSize={16} fontWeight="bold">
+            {fundItem.product_name}
+          </Text>
+        </S.WrapperTitle>
+        <S.WrapperUserInfo>
+          <Text fontSize={14} fontWeight="bold">
+            {fundItem.category_name} | {fundItem.user}
+          </Text>
+        </S.WrapperUserInfo>
+        <Line
+          percent={fundItem.goal_percent}
+          trailWidth="2"
+          strokeWidth="2"
+          strokeColor="#00B2B2"
+        />
+        <S.WrapperGoal>
+          <S.WrapperGoalPercent>
+            <Text fontSize={17} fontWeight="bold">
+              {fundItem.goal_percent}%
+            </Text>
+          </S.WrapperGoalPercent>
+          <S.WrapperGoalOther>
+            <Text fontSize={14} fontWeight="bold">
+              {fundItem.goal_price.toLocaleString('ko-KR')}원
+            </Text>
+            <Text fontSize={14} fontWeight="bold">
+              {fundItem.remaining_days}일 남음
+            </Text>
+          </S.WrapperGoalOther>
+        </S.WrapperGoal>
+      </S.WrapperInfo>
+    </S.WrapperCard>
+  );
+};
+
+export default ItemCard;

--- a/src/pages/Main/ItemCard/ItemCard.styled.js
+++ b/src/pages/Main/ItemCard/ItemCard.styled.js
@@ -1,0 +1,65 @@
+import styled from 'styled-components';
+
+export const WrapperCard = styled.article`
+  display: flex;
+  flex-direction: column;
+  height: 330px;
+  width: 100%;
+  padding-bottom: 20px;
+`;
+
+export const ImageBox = styled.div`
+  position: relative;
+  width: 100%;
+  height: 170px;
+  overflow: hidden;
+  border-radius: 5px;
+`;
+
+export const CardImage = styled.img`
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: 100%;
+  transform: translateY(-50%);
+`;
+
+export const WrapperInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+`;
+
+export const WrapperTitle = styled.div`
+  padding: 15px 0;
+  height: 67px;
+  width: 100%;
+  line-height: 22px;
+`;
+
+export const WrapperUserInfo = styled.div`
+  height: 20px;
+  color: #90949c;
+  margin-bottom: 12px;
+`;
+
+export const WrapperGoal = styled.div`
+  display: flex;
+  height: 20px;
+  margin-top: 5px;
+`;
+
+export const WrapperGoalPercent = styled.div`
+  display: flex;
+  align-items: flex-end;
+  margin-right: 5px;
+  color: #00b2b2;
+`;
+
+export const WrapperGoalOther = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  flex: 1;
+  color: #90949c;
+`;

--- a/src/pages/Main/ItemCards/ItemCards.js
+++ b/src/pages/Main/ItemCards/ItemCards.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import ItemCard from '../ItemCard/ItemCard';
+import * as S from './ItemCards.styled';
+
+const ItemCards = ({ fundItems }) => {
+  return (
+    <S.WrapperCards>
+      {fundItems.map(fundItem => {
+        return <ItemCard key={fundItem.product_id} fundItem={fundItem} />;
+      })}
+    </S.WrapperCards>
+  );
+};
+
+export default ItemCards;

--- a/src/pages/Main/ItemCards/ItemCards.styled.js
+++ b/src/pages/Main/ItemCards/ItemCards.styled.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+export const WrapperCards = styled.section`
+  display: grid;
+  grid-template-columns: repeat(3, calc(33.33333% - 30px));
+  grid-row-gap: 40px;
+  grid-column-gap: 40px;
+  width: 1000px;
+  padding: 30px 0;
+`;

--- a/src/pages/Main/Main.js
+++ b/src/pages/Main/Main.js
@@ -1,7 +1,30 @@
 import React from 'react';
+import ItemCards from './ItemCards/ItemCards';
+import * as S from './Main.styled';
+import useFetch from '../../hooks/useFetch';
+import HttpClient from '../../services/wecode';
 
-const Main = props => {
-  return <>Main</>;
+const httpClient = new HttpClient(process.env.REACT_APP_LOCAL_URL);
+
+const Main = () => {
+  const {
+    loading,
+    error,
+    payload: { products },
+  } = useFetch({
+    httpClient,
+    url: `/products/list`,
+  });
+
+  if (loading) return <p>Loadding</p>;
+
+  if (error) return <p>{error}</p>;
+
+  return (
+    <S.WrapperMain>
+      <ItemCards fundItems={products} />
+    </S.WrapperMain>
+  );
 };
 
 export default Main;

--- a/src/pages/Main/Main.styled.js
+++ b/src/pages/Main/Main.styled.js
@@ -1,0 +1,8 @@
+import styled from 'styled-components';
+
+export const WrapperMain = styled.main`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100vw;
+`;

--- a/src/services/wecode.js
+++ b/src/services/wecode.js
@@ -1,0 +1,18 @@
+import axios from 'axios';
+
+export default class HttpClient {
+  baseURL = '';
+  httpClient = null;
+
+  constructor(baseURL) {
+    this.baseURL = baseURL;
+    this.httpClient = axios.create({
+      baseURL: baseURL,
+    });
+  }
+
+  async getData(url) {
+    const data = await this.httpClient.get(url);
+    return data;
+  }
+}


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [x] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- 메인 페이지 아이템 grid 레이아웃 작성
- 서버 통신 service class 구현해보기

<br />

## :: 구현 사항 설명 
- 메인 페이지에서 표시 될 아이템 리스트에 대한 레이아웃 작성
- B/E와 통신 될 key 기준으로 상수값을 활용하여 여러 아이템이 그려지도록 작성
- 추 후 B/E와 통신 필요

### 2022.07.08
- B/E API 활용하여 데이터 불러오도록 기능 구현
- useFetch custom hook 생성
- 서버와 통신 할 service class 생성
    - useFetch hook 안에서 service class instance를 받아서 서버와 통신하도록 변경