### PR TITLE
[34기 서한샘]ADD : 스크롤 마지막까지 내리면 새로운 아이템 조회되도록 수정

### DIFF
--- a/src/hooks/useFetch.js
+++ b/src/hooks/useFetch.js
@@ -1,13 +1,18 @@
 import { useCallback, useState, useEffect } from 'react';
 
-export default function useFetch({ httpClient, url, skip = false }) {
+export default function useFetch({
+  httpClient,
+  url,
+  params = {},
+  skip = false,
+}) {
   const [payload, setPayload] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
 
   const getData = useCallback(async () => {
     try {
-      const { data } = await httpClient.getData(url);
+      const { data } = await httpClient.getData(url, params);
       setPayload(data);
     } catch (e) {
       console.error('error!!', e);

--- a/src/pages/Main/Main.js
+++ b/src/pages/Main/Main.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import ItemCards from './ItemCards/ItemCards';
 import * as S from './Main.styled';
 import useFetch from '../../hooks/useFetch';
@@ -12,7 +12,45 @@ const Main = () => {
   const { loading, error, payload } = useFetch({
     httpClient,
     url: `/products`,
+    params: { offset: 0, limit: ITEM_CARD_LOAD_COUNT },
   });
+
+  const [moreProducts, setMoreProduct] = useState([]);
+  const [isNewLoad, setIsNewLoad] = useState(false);
+
+  const infiniteScroll = useCallback(() => {
+    const scrollHeight = document.documentElement.scrollHeight;
+    const scrollTop = document.documentElement.scrollTop;
+    const clientHeight = document.documentElement.clientHeight;
+
+    const isLoadNewData = scrollHeight - 400 < scrollTop + clientHeight;
+
+    if (isNewLoad || !isLoadNewData) return;
+    setIsNewLoad(true);
+  }, [isNewLoad]);
+
+  const loadNewData = useCallback(async () => {
+    const { data } = await httpClient.getData('/products', {
+      offset:
+        (moreProducts.length / ITEM_CARD_LOAD_COUNT + 1) * ITEM_CARD_LOAD_COUNT,
+      limit: ITEM_CARD_LOAD_COUNT,
+    });
+
+    setMoreProduct(preventData => [...preventData, ...data.products]);
+    setIsNewLoad(false);
+  }, [moreProducts.length]);
+
+  useEffect(() => {
+    window.addEventListener('scroll', infiniteScroll);
+    return () => {
+      window.removeEventListener('scroll', infiniteScroll);
+    };
+  }, [infiniteScroll]);
+
+  useEffect(() => {
+    if (!isNewLoad) return;
+    loadNewData();
+  }, [isNewLoad, loadNewData]);
 
   if (loading) return <p>Loadding</p>;
   if (error) return <p>{error}</p>;
@@ -20,120 +58,11 @@ const Main = () => {
     <S.WrapperMain>
       <SimpleSlider />
       <Paging categories={CATEGORIES} />
-      <ItemCards fundItems={payload.products} />
+      <ItemCards fundItems={[...payload.products, ...moreProducts]} />
     </S.WrapperMain>
   );
 };
 
-const CATEGORIES = [
-  {
-    id: 1,
-    image_url:
-      'https://cdn.wadiz.kr/ft/images/green001/2022/0711/20220711111005281_null.jpg',
-    title: '펀딩야시장',
-  },
-  {
-    id: 2,
-    image_url:
-      'https://static.wadiz.kr/assets/reward-category/reward_banner_thumb/reward_banner_thumb_287.jpg',
-    title: '테크.가전',
-  },
-  {
-    id: 3,
-    image_url:
-      'https://static.wadiz.kr/assets/reward-category/reward_banner_thumb/reward_banner_thumb_288.jpg',
-    title: '패션.잡화',
-  },
-  {
-    id: 4,
-    image_url:
-      'https://static.wadiz.kr/assets/reward-category/reward_banner_thumb/reward_banner_thumb_311.jpg',
-    title: '뷰티',
-  },
-  {
-    id: 5,
-    image_url:
-      'https://static.wadiz.kr/assets/reward-category/reward_banner_thumb/reward_banner_thumb_289.jpg',
-    title: '푸드',
-  },
-  {
-    id: 6,
-    image_url:
-      'https://static.wadiz.kr/assets/reward-category/reward_banner_thumb/reward_banner_thumb_310.jpg',
-    title: '홈.리빙',
-  },
-  {
-    id: 7,
-    image_url:
-      'https://static.wadiz.kr/assets/reward-category/reward_banner_thumb/reward_banner_thumb_296.jpg',
-    title: '여행.레저',
-  },
-  {
-    id: 8,
-    image_url:
-      'https://static.wadiz.kr/assets/reward-category/reward_banner_thumb/reward_banner_thumb_297.jpg',
-    title: '스포츠.모빌리티',
-  },
-  {
-    id: 9,
-    image_url:
-      'https://static.wadiz.kr/assets/reward-category/reward_banner_thumb/reward_banner_thumb_character.jpg',
-    title: '캐릭터.굿즈',
-  },
-  {
-    id: 10,
-    image_url:
-      'https://static.wadiz.kr/assets/reward-category/reward_banner_thumb/reward_banner_thumb_309.jpg',
-    title: '베이비.키즈',
-  },
-  {
-    id: 11,
-    image_url:
-      'https://static.wadiz.kr/assets/reward-category/reward_banner_thumb/reward_banner_thumb_308.jpg',
-    title: '반려동물',
-  },
-  {
-    id: 12,
-    image_url:
-      'https://static.wadiz.kr/assets/reward-category/reward_banner_thumb/reward_banner_thumb_292.jpg',
-    title: '게임.취미',
-  },
-  {
-    id: 13,
-    image_url:
-      'https://static.wadiz.kr/assets/reward-category/reward_banner_thumb/reward_banner_thumb_294.jpg',
-    title: '컬쳐.아티스트',
-  },
-  {
-    id: 14,
-    image_url:
-      'https://static.wadiz.kr/assets/reward-category/reward_banner_thumb/reward_banner_thumb_316.jpg',
-    title: '클래스.컨설팅',
-  },
-  {
-    id: 15,
-    image_url:
-      'https://static.wadiz.kr/assets/reward-category/reward_banner_thumb/reward_banner_thumb_293.jpg',
-    title: '출판',
-  },
-  {
-    id: 16,
-    image_url:
-      'https://static.wadiz.kr/assets/reward-category/reward_banner_thumb/reward_banner_thumb_295.jpg',
-    title: '소셜.캠페인',
-  },
-  {
-    id: 17,
-    image_url:
-      'https://static.wadiz.kr/assets/reward-category/reward_banner_thumb/reward_banner_thumb_312.jpg',
-    title: '기부.후원',
-  },
-  {
-    id: 18,
-    image_url:
-      'https://static.wadiz.kr/assets/reward-category/reward_banner_thumb/reward_banner_thumb_313.jpg',
-    title: '모임',
-  },
-];
+const ITEM_CARD_LOAD_COUNT = 12;
 
 export default Main;

--- a/src/services/wecode.js
+++ b/src/services/wecode.js
@@ -11,8 +11,8 @@ export default class HttpClient {
     });
   }
 
-  async getData(url) {
-    const data = await this.httpClient.get(url);
+  async getData(url, params = {}) {
+    const data = await this.httpClient.get(url, { params });
     return data;
   }
 }


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- 메인 페이지에서 기본으로 12개 아이템을 보여주고 스크롤을 내리면 새로운 아이템이 조회되도록 수정

<br />

## :: 구현 사항 설명 
- 메인 페이지의 스크롤 최대값을 구해 지금 맨 아래 스크롤에 위치했는지 유무를 파악 할 수 있도록 기능 추가
- 맨 아래 스크롤까지 왔을 경우 새로운 아이템을 백엔드에 요청하도록 작업 진행

<br />

## :: 성장 포인트
- 스크롤 이벤트에 대해 조금 더 공부하는 계기가 되었습니다!
- 바닐라 자바스크립트로 작업하는 부분이 익숙하지 않아 이벤트의 구독과, 구독해제라는 개념이 모호했는데 한번 집고 갈 수 있는 작업이였습니다!